### PR TITLE
Remove unused modules from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,21 +6,18 @@ require (
 	github.com/DataDog/zstd v1.4.8 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/PaesslerAG/gval v1.1.0
-	github.com/creachadair/jrpc2 v0.12.0
 	github.com/cskr/pubsub v1.0.2
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/gochik/gpio v1.2.0
 	github.com/gochik/modbus v0.0.0-20200807142711-9712c9793b42
 	github.com/gochik/sunrisesunset v0.0.0-20201116161600-d896ce6e891a
-	github.com/godbus/dbus v4.1.0+incompatible
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
-	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mitchellh/copystructure v1.1.2 // indirect
 	github.com/mitchellh/mapstructure v1.4.1
@@ -37,9 +34,8 @@ require (
 	go.step.sm/cli-utils v0.3.0 // indirect
 	go.step.sm/crypto v0.8.2
 	golang.org/x/crypto v0.0.0-20210503195802-e9a32991a82e // indirect
-	golang.org/x/net v0.0.0-20210505024714-0287a6fb4125
+	golang.org/x/net v0.0.0-20210505024714-0287a6fb4125 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6 // indirect
 	gopkg.in/tucnak/telebot.v2 v2.3.5
-	gopkg.in/yaml.v2 v2.3.0 // indirect
 )


### PR DESCRIPTION
Via "go mod tidy".

I found this while upgrading uses of one of my modules, and noticed
that it was declared but not actually used in this package.